### PR TITLE
Fix login issue with scopes

### DIFF
--- a/src/main/scala/com/kubukoz/next/Login.scala
+++ b/src/main/scala/com/kubukoz/next/Login.scala
@@ -34,7 +34,7 @@ object Login {
         .uri("https://accounts.spotify.com/authorize")
         .withQueryParam("client_id", config.clientId)
         .withQueryParam("client_secret", config.clientSecret)
-        .withQueryParam("scopes", scopes.mkString(" "))
+        .withQueryParam("scope", scopes.mkString(" "))
         .withQueryParam("redirect_uri", s"http://localhost:${config.loginPort}/login")
         .withQueryParam("response_type", "token")
 


### PR DESCRIPTION
This PR fixes authentication requests by changing the scopes list param to `scope` as per: https://developer.spotify.com/documentation/general/guides/authorization-guide/