### PR TITLE
Update README to match redirect URI in Login.scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A small program making it easier to filter out music on Spotify.
 
 ## Installation
 
-1. Create an application in the Spotify API dashboard. Add a redirect URI pointing to `http://localhost:port`, where `port` is a port of your choice. You'll need to configure the port in the config file.
+1. Create an application in the Spotify API dashboard. Add a redirect URI pointing to `http://localhost:port/login`, where `port` is a port of your choice. You'll need to configure the port in the config file.
 
 1. `sbt stage`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A small program making it easier to filter out music on Spotify.
 
 ## Installation
 
-1. Create an application in the Spotify API dashboard. Add a redirect URI pointing to `http://localhost:port/login`, where `port` is a port of your choice. You'll need to configure the port in the config file.
+1. Create an application in the Spotify API dashboard. Add a redirect URI pointing to `http://localhost:4321/login`. The port `4321` is configured in the `.spotify-next.json` config file.
 
 1. `sbt stage`
 


### PR DESCRIPTION
This PR changes the instructions in the README to match the redirect URI used in [Login.scala](https://github.com/kubukoz/spotify-next/blob/830ab8547e19b4c326c3cea3f651ecf3cd6c9c13/src/main/scala/com/kubukoz/next/Login.scala#L38)