### PR TITLE
Create config file if not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,18 @@ A small program making it easier to filter out music on Spotify.
 
 ## Installation
 
-1. Create an application in the Spotify API dashboard. Add a redirect URI pointing to `http://localhost:4321/login`. The port `4321` is configured in the `.spotify-next.json` config file.
+1. Create an application in the Spotify API dashboard. Add a redirect URI pointing to `http://localhost:4321/login`.
+The port `4321` is configured in the `.spotify-next.json` config file (see [usage](#usage)).
 
 1. `sbt stage`
 
-1. Create a file in your home directory, named `.spotify-next.json`:
-
-  ```json
-  {
-    "clientId": "(your app's client id)",
-    "clientSecret": "(your app's secret)",
-    "loginPort": 4321,
-    "token": ""
-  }
-  ```
-
-The token can be empty for now, it'll be replaced with a real one when you log in.
-
-A server will start on the configured port only when the login flow is triggered.
-
 ## Usage
+
+The application requires some configuration (e.g. the client ID for the Spotify Web API).
+It's stored in a file at `~/.spotify-next.json`.
+When you first run the application, or if that file is deleted, the application will ask and attempt to create one.
+
+The configuration defines the port for the embedded HTTP server used for authentication. The server server will only start when the login flow is triggered, and stop afterwards.
 
 ```
 $ ./target/universal/stage/bin/spotify-next --help

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ val commonSettings = Seq(
   name := "spotify-next",
   updateOptions := updateOptions.value.withGigahorse(false),
   libraryDependencies ++= Seq(
+    "org.typelevel" %% "simulacrum" % "1.0.0",
     "dev.profunktor" %% "console4cats" % "0.8.1",
     "com.monovore" %% "decline-effect" % "1.0.0",
     "org.http4s" %% "http4s-dsl" % "0.21.0-M6",

--- a/src/main/scala/com/kubukoz/next/ConfigLoader.scala
+++ b/src/main/scala/com/kubukoz/next/ConfigLoader.scala
@@ -6,6 +6,7 @@ import io.circe.Printer
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import cats.tagless.finalAlg
+import java.nio.file.NoSuchFileException
 
 @finalAlg
 trait ConfigLoader[F[_]] {
@@ -14,12 +15,36 @@ trait ConfigLoader[F[_]] {
 }
 
 object ConfigLoader extends LowPriority {
+  type MonadThrow[F[_]] = MonadError[F, Throwable]
 
-  def cached[F[_]: Sync](underlying: ConfigLoader[F]): F[ConfigLoader[F]] =
-    underlying.loadConfig.flatMap(Ref.of(_)).map { ref =>
+  def cached[F[_]: Sync]: ConfigLoader[F] => F[ConfigLoader[F]] =
+    underlying =>
+      underlying.loadConfig.flatMap(Ref.of(_)).map { ref =>
+        new ConfigLoader[F] {
+          def saveConfig(config: Config): F[Unit] = underlying.saveConfig(config) *> ref.set(config)
+          val loadConfig: F[Config] = ref.get
+        }
+      }
+
+  def withCreateFileIfMissing[F[_]: Console: MonadThrow](configPath: Path): ConfigLoader[F] => ConfigLoader[F] =
+    underlying => {
+      def askToCreateFile(originalException: NoSuchFileException): F[Unit] = {
+        implicit val showPath: Show[Path] = Show.fromToString
+        val validInput = "Y"
+
+        Console[F].putStrLn(show"Didn't find config file at $configPath. Should I create one? ($validInput/n)") *>
+          Console[F].readLn.map(_.trim).ensure(originalException)(_.equalsIgnoreCase("Y")).void
+      }
+
       new ConfigLoader[F] {
-        def saveConfig(config: Config): F[Unit] = underlying.saveConfig(config) *> ref.set(config)
-        val loadConfig: F[Config] = ref.get
+        val loadConfig: F[Config] = underlying.loadConfig.recoverWith {
+          case e: NoSuchFileException =>
+            askToCreateFile(e) *> Config.initial.pure[F].flatTap(saveConfig) <*
+              Console[F]
+                .putStrLn(s"Created file at $configPath, remember to fill in your Spotify API application's data")
+        }
+
+        def saveConfig(config: Config): F[Unit] = underlying.saveConfig(config)
       }
     }
 

--- a/src/main/scala/com/kubukoz/next/ConfigLoader.scala
+++ b/src/main/scala/com/kubukoz/next/ConfigLoader.scala
@@ -37,7 +37,7 @@ object ConfigLoader extends LowPriority {
 
         for {
           _ <- Console[F].putStrLn(askMessage)
-          _ <- Console[F].readLn.map(_.trim).ensure(originalException)(_.equalsIgnoreCase("Y"))
+          _ <- Console[F].readLn.map(_.trim).ensure(originalException)(_.equalsIgnoreCase(validInput))
           clientId <- ConsoleRead.readWithPrompt[F, String]("Client ID")
           clientSecret <- ConsoleRead.readWithPrompt[F, String]("Client secret")
         } yield Config(clientId, clientSecret, Config.defaultPort, Config.Token.empty)

--- a/src/main/scala/com/kubukoz/next/Program.scala
+++ b/src/main/scala/com/kubukoz/next/Program.scala
@@ -16,7 +16,7 @@ import com.olegpy.meow.hierarchy.deriveApplicativeAsk
 import ConfigLoader.deriveAskFromLoader
 
 object Program {
-  val configPath = Paths.get(System.getProperty("user.home") + "/.spotify-next.json")
+  val configPath = Paths.get(System.getProperty("user.home")).resolve(".spotify-next.json")
 
   def makeLoader[F[_]: Sync: ContextShift] =
     Blocker[F].map(ConfigLoader.default[F](configPath, _)).evalMap(ConfigLoader.cached(_))

--- a/src/main/scala/com/kubukoz/next/Program.scala
+++ b/src/main/scala/com/kubukoz/next/Program.scala
@@ -18,8 +18,12 @@ import ConfigLoader.deriveAskFromLoader
 object Program {
   val configPath = Paths.get(System.getProperty("user.home")).resolve(".spotify-next.json")
 
-  def makeLoader[F[_]: Sync: ContextShift] =
-    Blocker[F].map(ConfigLoader.default[F](configPath, _)).evalMap(ConfigLoader.cached(_))
+  def makeLoader[F[_]: Sync: ContextShift: Console] = Blocker[F].evalMap { blocker =>
+    ConfigLoader
+      .cached[F]
+      .compose(ConfigLoader.withCreateFileIfMissing[F](configPath))
+      .apply(ConfigLoader.default[F](configPath, blocker))
+  }
 
   def makeClient[F[_]: ConcurrentEffect: ContextShift: Timer: Console: ConfigLoader: Login]: Resource[F, Client[F]] =
     BlazeClientBuilder(ExecutionContext.global)

--- a/src/main/scala/com/kubukoz/next/util/ConsoleRead.scala
+++ b/src/main/scala/com/kubukoz/next/util/ConsoleRead.scala
@@ -1,0 +1,22 @@
+package com.kubukoz.next.util
+
+import simulacrum.typeclass
+import types._
+
+@typeclass
+trait ConsoleRead[A] {
+  def read(s: String): Either[Throwable, A]
+}
+
+object ConsoleRead {
+
+  implicit val readString: ConsoleRead[String] = new ConsoleRead[String] {
+    def read(s: String): Either[Throwable, String] = Right(s)
+  }
+
+  def readWithPrompt[F[_]: Console: MonadThrow, A: ConsoleRead](promptText: String): F[A] =
+    Console[F].putStr(promptText + ": ") *> Console[F]
+      .readLn
+      .map(Option(_).getOrElse(""))
+      .flatMap(ConsoleRead[A].read(_).liftTo[F])
+}

--- a/src/main/scala/com/kubukoz/next/util/config.scala
+++ b/src/main/scala/com/kubukoz/next/util/config.scala
@@ -9,6 +9,8 @@ final case class Config(clientId: String, clientSecret: String, loginPort: Int, 
 object Config extends AskFor[Config] {
   implicit val config = Configuration.default
 
+  val initial: Config = Config("your-client-id", "your-client-secret", 4321, Token(""))
+
   final case class Token(value: String) extends AnyVal
 
   object Token extends AskFor[Token] {

--- a/src/main/scala/com/kubukoz/next/util/config.scala
+++ b/src/main/scala/com/kubukoz/next/util/config.scala
@@ -9,12 +9,14 @@ final case class Config(clientId: String, clientSecret: String, loginPort: Int, 
 object Config extends AskFor[Config] {
   implicit val config = Configuration.default
 
-  val initial: Config = Config("your-client-id", "your-client-secret", 4321, Token(""))
+  val defaultPort: Int = 4321
 
   final case class Token(value: String) extends AnyVal
 
   object Token extends AskFor[Token] {
     implicit val codec: Codec[Token] = deriveUnwrappedCodec
+
+    val empty: Token = Token("")
   }
 
   implicit val codec: Codec[Config] = deriveConfiguredCodec

--- a/src/main/scala/com/kubukoz/next/util/types.scala
+++ b/src/main/scala/com/kubukoz/next/util/types.scala
@@ -1,0 +1,5 @@
+package com.kubukoz.next.util
+
+object types {
+  type MonadThrow[F[_]] = MonadError[F, Throwable]
+}


### PR DESCRIPTION
This is a bit problematic, because creating a file with defaults will force the user to restart the application after they've updated their client id/secret (in order to reload the file, which is currently cached until successful login).

For that reason, the app will ask for the Client ID / secret before creating the file. In the future, that might be replaced with a file watcher polling the file system for changes every N seconds, and updating the cache accordingly.