### PR TITLE
Support the new uri format for playlists

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val compilerPlugins = List(
 )
 
 val commonSettings = Seq(
-  scalaVersion := "2.13.1",
+  scalaVersion := "2.13.3",
   scalacOptions -= "-Xfatal-warnings",
   scalacOptions ++= Seq(
     "-Ymacro-annotations",

--- a/src/main/scala/com/kubukoz/next/Login.scala
+++ b/src/main/scala/com/kubukoz/next/Login.scala
@@ -9,7 +9,6 @@ import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 import com.kubukoz.next.util.Config.Token
 import org.http4s.client.Client
-import org.http4s.Request
 import org.http4s.Method.POST
 import org.http4s.Request
 import com.kubukoz.next.api.spotify.TokenResponse

--- a/src/main/scala/com/kubukoz/next/api/spotify.scala
+++ b/src/main/scala/com/kubukoz/next/api/spotify.scala
@@ -77,17 +77,22 @@ object spotify {
 
   sealed trait PlayerContext extends Product with Serializable
 
-  final case class PlaylistUri(user: String, playlist: String)
+  final case class PlaylistUri(playlist: String, user: String = null)
 
   object PlaylistUri {
 
     implicit val codec: Codec[PlaylistUri] = Codec.from(
       Decoder[String].emap {
-        case s"spotify:user:$userId:playlist:$playlistId" => PlaylistUri(userId, playlistId).asRight
+        case s"spotify:user:$userId:playlist:$playlistId" => PlaylistUri(playlistId, userId).asRight
+        case s"spotify:playlist:$playlistId" => PlaylistUri(playlistId).asRight
         case literallyAnythingElse                        => (literallyAnythingElse + " is not a playlist URI").asLeft
       },
       Encoder[String].contramap { uri =>
-        show"spotify:user:${uri.user}:playlist:${uri.playlist}"
+        if (uri.user != null) {
+          show"spotify:user:${uri.user}:playlist:${uri.playlist}"
+        } else {
+          show"spotify:playlist:${uri.playlist}"
+        }
       }
     )
 

--- a/src/main/scala/com/kubukoz/next/util/middlewares.scala
+++ b/src/main/scala/com/kubukoz/next/util/middlewares.scala
@@ -17,7 +17,7 @@ object middlewares {
 
   def retryUnauthorizedWith[F[_]: Sync: Console](beforeRetry: F[Unit]): Client[F] => Client[F] = {
     def doBeforeRetry(response: Response[F]) = {
-      val showBody = response.bodyAsText.compile.string.flatMap(Console[F].putStrLn)
+      val showBody = response.bodyText.compile.string.flatMap(Console[F].putStrLn)
 
       Resource.liftF(
         Console[F].putStrLn("Received unauthorized response") *>
@@ -52,7 +52,7 @@ object middlewares {
         case response if response.status.isSuccess => response.pure[F]
         case response                              =>
           response
-            .bodyAsText
+            .bodyText
             .compile
             .string
             .flatTap(text => Console[F].putError(s"Request $req failed, response: " + text))


### PR DESCRIPTION
[Spotify has two formats for playlists now.](https://developer.spotify.com/community/news/2018/06/12/changes-to-playlist-uris/) It used to be `spotify:user:spotify:playlist:37i9dQZF1DZ06evO3OC4Te`, and is now `spotify:playlist:37i9dQZF1DZ06evO3OC4Te`.

My playlists are in the new format, so I updated this to use both formats.

I don't know Scala or this tool very well so I imagine there's a cleaner solution. But it works for me and I thought I'd share instead of just making an issue 😄 

Thanks for making this tool!