### PR TITLE
Upgrade to Scala Native 0.5.11

### DIFF
--- a/app/.jvm/src/main/scala/com/kubukoz/next/RuntimePlatform.scala
+++ b/app/.jvm/src/main/scala/com/kubukoz/next/RuntimePlatform.scala
@@ -1,7 +1,0 @@
-package com.kubukoz.next
-
-import cats.effect.unsafe.IORuntime
-
-object RuntimePlatform {
-  val default: IORuntime = IORuntime.global
-}

--- a/app/.native/src/main/scala/com/kubukoz/next/RuntimePlatform.scala
+++ b/app/.native/src/main/scala/com/kubukoz/next/RuntimePlatform.scala
@@ -1,8 +1,0 @@
-package com.kubukoz.next
-
-import epollcat.unsafe.EpollRuntime
-import cats.effect.unsafe.IORuntime
-
-object RuntimePlatform {
-  val default: IORuntime = EpollRuntime.global
-}

--- a/app/src/main/scala/com/kubukoz/next/Main.scala
+++ b/app/src/main/scala/com/kubukoz/next/Main.scala
@@ -15,7 +15,6 @@ import cats.effect.implicits.*
 import LoginProcess.given
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.noop.NoOpLogger
-import cats.effect.unsafe.IORuntime
 import fs2.io.file.Files
 import fs2.io.net.Network
 import org.http4s.client.Client
@@ -63,8 +62,6 @@ object Choice {
 }
 
 object Main extends CommandIOApp(name = "spotify-next", header = "spotify-next: Gather great music.", version = BuildInfo.version) {
-
-  override protected def runtime: IORuntime = RuntimePlatform.default
 
   import Program.*
   given Logger[IO] = NoOpLogger[IO]

--- a/build.sbt
+++ b/build.sbt
@@ -62,9 +62,9 @@ val commonSettings = Seq(
     // "2000"
   ),
   libraryDependencies ++= Seq(
-    "org.typelevel" %%% "cats-effect" % "3.6.3",
+    "org.typelevel" %%% "cats-effect" % "3.7.0",
     "org.scalameta" %%% "munit" % "1.0.0" % Test,
-    "org.typelevel" %%% "munit-cats-effect" % "2.1.0" % Test
+    "org.typelevel" %%% "munit-cats-effect" % "2.2.0" % Test
   ),
   addCompilerPlugins,
   Compile / doc / sources := Nil
@@ -137,15 +137,15 @@ val app = crossProject(JVMPlatform, NativePlatform)
   .settings(
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %%% "smithy4s-http4s" % smithy4sVersion.value,
-      "org.typelevel" %%% "cats-mtl" % "1.4.0",
-      "com.monovore" %%% "decline-effect" % "2.4.1",
-      "org.http4s" %%% "http4s-dsl" % "0.23.30",
-      "org.http4s" %%% "http4s-ember-server" % "0.23.30",
-      "org.http4s" %%% "http4s-ember-client" % "0.23.30",
-      "org.http4s" %%% "http4s-circe" % "0.23.30",
-      "io.circe" %%% "circe-parser" % "0.14.8",
-      "org.typelevel" %%% "log4cats-noop" % "2.7.1",
-      "org.polyvariant" %%% "colorize" % "0.3.2"
+      "org.typelevel" %%% "cats-mtl" % "1.6.0",
+      "com.monovore" %%% "decline-effect" % "2.6.2",
+      "org.http4s" %%% "http4s-dsl" % "0.23.34",
+      "org.http4s" %%% "http4s-ember-server" % "0.23.34",
+      "org.http4s" %%% "http4s-ember-client" % "0.23.34",
+      "org.http4s" %%% "http4s-circe" % "0.23.34",
+      "io.circe" %%% "circe-parser" % "0.14.15",
+      "org.typelevel" %%% "log4cats-noop" % "2.8.0",
+      "org.polyvariant" %%% "colorize" % "0.4.0"
       // waiting
       // "dev.optics" %%% "monocle-core" % "3.1.0"
     ),
@@ -160,13 +160,6 @@ val app = crossProject(JVMPlatform, NativePlatform)
         "ch.qos.logback" % "logback-classic" % "1.5.18"
       )
     ).enablePlugins(JavaAppPackaging)
-  )
-  .nativeConfigure(
-    _.settings(
-      libraryDependencies ++= Seq(
-        "com.armanbilge" %%% "epollcat" % "0.1.7"
-      )
-    )
   )
 
 val root =

--- a/derivation.nix
+++ b/derivation.nix
@@ -5,7 +5,7 @@ let pname = "spotify-next"; in
 mkSbtDerivation {
   inherit pname;
   version = "0.1.0";
-  depsSha256 = "sha256-nPDkvJR87D1iiXIpivZCEB+yx4pE04PtjFd8rcNH54Q=";
+  depsSha256 = "sha256-5eu3lgUw9o0phd/LL4V+P8XP/8uSqhToi/DonqlCBQk=";
 
   buildInputs = [ which clang ];
   nativeBuildInputs = [ s2n-tls ];
@@ -16,11 +16,11 @@ mkSbtDerivation {
   src = gitignore-source.lib.gitignoreSource ./.;
 
   buildPhase = ''
-    sbt nativeLink
+    sbt appNative/nativeLink
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    cp app/.native/target/scala-3.3.1/spotify-next-out $out/bin/$pname
+    cp app/.native/target/scala-3.7.3/spotify-next $out/bin/$pname
   '';
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -37,11 +40,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694102001,
-        "narHash": "sha256-vky6VPK1n1od6vXbqzOXnekrQpTL4hbPAwUhT5J9c9E=",
+        "lastModified": 1762808025,
+        "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "9e21c80adf67ebcb077d75bd5e7d724d21eeafd6",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
         "type": "github"
       },
       "original": {
@@ -52,15 +55,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664152164,
-        "narHash": "sha256-UQBQ390B2g7tIT4bULsgwXJeFdJxtlwoe25Ge25B7Go=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "70168c4fde028ec5f7876da7c662cd9a7854c267",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -105,6 +109,21 @@
       "original": {
         "owner": "zaninime",
         "repo": "sbt-derivation",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.sbt-derivation.url = "github:zaninime/sbt-derivation";
   inputs.gitignore-source.url = "github:hercules-ci/gitignore.nix";
@@ -16,7 +16,7 @@
       in
       {
         devShells.default = pkgs.mkShell {
-          nativeBuildInputs = [ pkgs.s2n-tls ];
+          nativeBuildInputs = [ pkgs.s2n-tls pkgs.clang ];
         };
         packages.default = pkgs.callPackage ./derivation.nix { inherit (inputs) gitignore-source; };
       }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,8 @@ addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.28.0")
 
-addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.18.50")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.18.51")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.11")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
 addDependencyTreePlugin


### PR DESCRIPTION
## Summary

- Upgrades to Scala Native 0.5.11 (from 0.4.17)
- Bumps all ecosystem deps to versions with SN 0.5 support: cats-effect 3.7.0, http4s 0.23.34, smithy4s 0.18.51, circe 0.14.15, decline 2.6.2, colorize 0.4.0, log4cats 2.8.0, cats-mtl 1.6.0
- Removes epollcat (no longer needed — SN 0.5 has built-in async I/O)
- Removes `RuntimePlatform` indirection, relies on `CommandIOApp` default runtime
- Updates flake.nix to nixpkgs-unstable (clang 21) so both `nix develop` and `nix build` work

## Test plan

- [x] `appNative/nativeLink` succeeds in nix dev shell
- [x] `nix build` produces a working binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)